### PR TITLE
Adds ability to secure images behind auth

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -3,6 +3,7 @@
 namespace DocsPen\Http\Controllers;
 
 use DocsPen\Exceptions\ImageUploadException;
+use DocsPen\Exceptions\NotFoundException;
 use DocsPen\Image;
 use DocsPen\Repos\EntityRepo;
 use DocsPen\Repos\ImageRepo;
@@ -28,6 +29,20 @@ class ImageController extends Controller
         $this->file = $file;
         $this->imageRepo = $imageRepo;
         parent::__construct();
+    }
+    
+    /**
+     * Provide an image file from storage.
+     * @param string $path
+     * @return mixed
+     */
+    public function showImage(string $path)
+    {
+        $path = storage_path('uploads/images/' . $path);
+        if (!file_exists($path)) {
+            abort(404);
+        }
+        return response()->file($path);
     }
 
     /**

--- a/app/Repos/ImageRepo.php
+++ b/app/Repos/ImageRepo.php
@@ -213,10 +213,10 @@ class ImageRepo
     {
         try {
             return $this->imageService->getThumbnail($image, $width, $height, $keepRatio);
-        } catch (FileNotFoundException $exception) {
-            $image->delete();
+        } catch (\Exception $exception) {
+            dd($exception);
 
-            return [];
+            return null;
         }
     }
 }

--- a/app/Services/AttachmentService.php
+++ b/app/Services/AttachmentService.php
@@ -9,18 +9,35 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class AttachmentService extends UploadService
 {
+    
+    /**
+     * Get the storage that will be used for storing files.
+     * @return \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    protected function getStorage()
+    {
+        if ($this->storageInstance !== null) return $this->storageInstance;
+        $storageType = config('filesystems.default');
+        // Override default location if set to local public to ensure not visible.
+        if ($storageType === 'local') {
+            $storageType = 'local_secure';
+        }
+        $this->storageInstance = $this->fileSystem->disk($storageType);
+        return $this->storageInstance;
+    }
+    
     /**
      * Get an attachment from storage.
      *
      * @param Attachment $attachment
      *
      * @return string
+     * 
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     public function getAttachmentFromStorage(Attachment $attachment)
     {
-        $attachmentPath = $this->getStorageBasePath().$attachment->path;
-
-        return $this->getStorage()->get($attachmentPath);
+        return $this->getStorage()->get($attachment->path);
     }
 
     /**
@@ -107,17 +124,6 @@ class AttachmentService extends UploadService
     }
 
     /**
-     * Get the file storage base path, amended for storage type.
-     * This allows us to keep a generic path in the database.
-     *
-     * @return string
-     */
-    private function getStorageBasePath()
-    {
-        return $this->isLocal() ? 'storage/' : '';
-    }
-
-    /**
      * Updates the file ordering for a listing of attached files.
      *
      * @param array $attachmentList
@@ -157,6 +163,8 @@ class AttachmentService extends UploadService
      * Delete a File from the database and storage.
      *
      * @param Attachment $attachment
+     * 
+     * @throws Exception
      */
     public function deleteFile(Attachment $attachment)
     {
@@ -178,11 +186,10 @@ class AttachmentService extends UploadService
      */
     protected function deleteFileInStorage(Attachment $attachment)
     {
-        $storedFilePath = $this->getStorageBasePath().$attachment->path;
         $storage = $this->getStorage();
-        $dirPath = dirname($storedFilePath);
+        $dirPath = dirname($attachment->path);
 
-        $storage->delete($storedFilePath);
+        $storage->delete($attachment->path);
         if (count($storage->allFiles($dirPath)) === 0) {
             $storage->deleteDirectory($dirPath);
         }
@@ -203,21 +210,19 @@ class AttachmentService extends UploadService
         $attachmentData = file_get_contents($uploadedFile->getRealPath());
 
         $storage = $this->getStorage();
-        $attachmentBasePath = 'uploads/files/'.date('Y-m-M').'/';
-        $storageBasePath = $this->getStorageBasePath().$attachmentBasePath;
+        $basePath = 'uploads/files/' . Date('Y-m-M') . '/';
 
         $uploadFileName = $attachmentName;
-        while ($storage->exists($storageBasePath.$uploadFileName)) {
+        while ($storage->exists($basePath . $uploadFileName)) {
             $uploadFileName = str_random(3).$uploadFileName;
         }
 
-        $attachmentPath = $attachmentBasePath.$uploadFileName;
-        $attachmentStoragePath = $this->getStorageBasePath().$attachmentPath;
+        $attachmentPath = $basePath . $uploadFileName;
 
         try {
-            $storage->put($attachmentStoragePath, $attachmentData);
+            $storage->put($attachmentPath, $attachmentData);
         } catch (Exception $e) {
-            throw new FileUploadException(trans('errors.path_not_writable', ['filePath' => $attachmentStoragePath]));
+            throw new FileUploadException(trans('errors.path_not_writable', ['filePath' => $attachmentPath]));
         }
 
         return $attachmentPath;

--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -97,10 +97,6 @@ class ImageService extends UploadService
 
         $imagePath = '/uploads/images/'.$type.'/'.date('Y-m-M').'/';
 
-        if ($this->isLocal()) {
-            $imagePath = '/public'.$imagePath;
-        }
-
         while ($storage->exists($imagePath.$imageName)) {
             $imageName = str_random(3).$imageName;
         }
@@ -111,10 +107,6 @@ class ImageService extends UploadService
             $storage->setVisibility($fullPath, 'public');
         } catch (Exception $e) {
             throw new ImageUploadException(trans('errors.path_not_writable', ['filePath' => $fullPath]));
-        }
-
-        if ($this->isLocal()) {
-            $fullPath = str_replace_first('/public', '', $fullPath);
         }
 
         $imageDetails = [
@@ -131,7 +123,8 @@ class ImageService extends UploadService
             $imageDetails['updated_by'] = $userId;
         }
 
-        $image = Image::forceCreate($imageDetails);
+        $image = (new Image());
+        $image->forceFill($imageDetails)->save();
 
         return $image;
     }
@@ -145,7 +138,7 @@ class ImageService extends UploadService
      */
     protected function getPath(Image $image)
     {
-        return ($this->isLocal()) ? ('public/'.$image->path) : $image->path;
+        return $image->path;
     }
 
     /**
@@ -184,9 +177,8 @@ class ImageService extends UploadService
         } catch (Exception $e) {
             if ($e instanceof \ErrorException || $e instanceof NotSupportedException) {
                 throw new ImageUploadException(trans('errors.cannot_create_thumbs'));
-            } else {
-                throw $e;
             }
+            throw $e;
         }
 
         if ($keepRatio) {
@@ -292,10 +284,7 @@ class ImageService extends UploadService
             $this->storageUrl = $storageUrl;
         }
 
-        if ($this->isLocal()) {
-            $filePath = str_replace_first('public/', '', $filePath);
-        }
-
-        return ($this->storageUrl == false ? rtrim(baseUrl(''), '/') : rtrim($this->storageUrl, '/')).$filePath;
+        $basePath = ($this->storageUrl == false) ? baseUrl('/') : $this->storageUrl;
+        return rtrim($basePath, '/') . $filePath;
     }
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -56,7 +56,12 @@ return [
 
         'local' => [
             'driver' => 'local',
-            'root'   => base_path(),
+            'root'   => public_path(),
+        ],
+
+        'local_secure' => [
+            'driver' => 'local',
+            'root'   => storage_path(),
         ],
 
         'ftp' => [

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,10 @@ Route::get('/translations', 'HomeController@getTranslations');
 
 // Authenticated routes...
 Route::group(['middleware' => 'auth'], function () {
+    
+    Route::get('/uploads/images/{path}', 'ImageController@showImage')
+        ->where('path', '.*$');
+    
     Route::group(['prefix' => 'pages'], function () {
         Route::get('/recently-created', 'PageController@showRecentlyCreated');
         Route::get('/recently-updated', 'PageController@showRecentlyUpdated');
@@ -88,13 +92,15 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('/@/all/{page}', 'ImageController@getAllForUserType');
         // Standard get, update and deletion for all types
         Route::get('/thumb/{id}/{width}/{height}/{crop}', 'ImageController@getThumbnail');
+        Route::get('/base64/{id}', 'ImageController@getBase64Image');
         Route::put('/update/{imageId}', 'ImageController@update');
+        Route::post('/drawing/upload', 'ImageController@uploadDrawing');
         Route::post('/{type}/upload', 'ImageController@uploadByType');
         Route::get('/{type}/all', 'ImageController@getAllByType');
         Route::get('/{type}/all/{page}', 'ImageController@getAllByType');
         Route::get('/{type}/search/{page}', 'ImageController@searchByType');
         Route::get('/gallery/{filter}/{page}', 'ImageController@getGalleryFiltered');
-        Route::delete('/{imageId}', 'ImageController@destroy');
+        Route::delete('/{id}', 'ImageController@destroy');
     });
 
     // Attachments routes

--- a/storage/uploads/images/.gitignore
+++ b/storage/uploads/images/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This feature puts images behind the authentication barrier so they are only viewable by logged-in users. Permission levels not taken into account, It's simply based on 'Is user authed?'.

Cannot be used alongside public viewing.
Set to be opt-in for now.

Public image access should still be served by the webserver as before, Secure image access goes through the app so will have a performance penalty.

Still in testing. Would be great for folks to test on their setups for any issues. (Do not test on production instances though). I experienced issues doing something similar when initially creating DocsPen but so far everything has been working without issue on my dev machine.

## Use Instructions
To use simply set `STORAGE_TYPE=local_secure` in your `.env` file.
Files will be stored in a `storage/uploads/images` folder similar to attachments.

If you are migrating to this option with existing images you will need to move all content in the folder `public/uploads/images` to `storage/uploads/images`.